### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/packages/editor/lib/tiptap.ts
+++ b/packages/editor/lib/tiptap.ts
@@ -80,24 +80,30 @@ const convertYouTubeImgToIframe = (html: string): string => {
 
   for (const image of images) {
     const { src } = image;
-    // Check if the image src contains a YouTube link
-    if (src.includes('youtube.com')) {
-      // Create a new div element to wrap the iframe
-      const div = window.document.createElement('div');
-      div.dataset.youtubeVideo = '';
-      div.dataset.youtubeVideo = '';
+    try {
+      const url = new URL(src);
+      // Check if the image src contains a YouTube link
+      if (url.hostname.includes('youtube.com')) {
+        // Create a new div element to wrap the iframe
+        const div = window.document.createElement('div');
+        div.dataset.youtubeVideo = '';
+        div.dataset.youtubeVideo = '';
 
-      // Create the iframe element
-      const iframe = window.document.createElement('iframe');
+        // Create the iframe element
+        const iframe = window.document.createElement('iframe');
 
-      // Set the src as it was in the <img>
-      iframe.src = src;
+        // Set the src as it was in the <img>
+        iframe.src = src;
 
-      // Append the iframe to the div
-      div.append(iframe);
+        // Append the iframe to the div
+        div.append(iframe);
 
-      // Replace the image with the new div
-      image.parentNode?.replaceChild(div, image);
+        // Replace the image with the new div
+        image.parentNode?.replaceChild(div, image);
+      }
+    } catch (e) {
+      // Handle invalid URL
+      console.error(`Invalid URL: ${src}`);
     }
   }
 

--- a/packages/editor/lib/tiptap.ts
+++ b/packages/editor/lib/tiptap.ts
@@ -82,8 +82,9 @@ const convertYouTubeImgToIframe = (html: string): string => {
     const { src } = image;
     try {
       const url = new URL(src);
-      // Check if the image src contains a YouTube link
-      if (url.hostname.includes('youtube.com')) {
+      // Check if the image src belongs to a trusted YouTube domain
+      const allowedYouTubeHosts = ['youtube.com', 'www.youtube.com'];
+      if (allowedYouTubeHosts.includes(url.hostname)) {
         // Create a new div element to wrap the iframe
         const div = window.document.createElement('div');
         div.dataset.youtubeVideo = '';


### PR DESCRIPTION
Potential fix for [https://github.com/haydenbleasel/eververse/security/code-scanning/3](https://github.com/haydenbleasel/eververse/security/code-scanning/3)

To fix the problem, we need to ensure that the check for "youtube.com" is performed on the host part of the URL, rather than as a substring of the entire URL. This can be achieved by parsing the URL and then checking the host component.

The best way to fix this without changing existing functionality is to use the `URL` constructor available in modern JavaScript environments to parse the URL and then check the `hostname` property. This ensures that "youtube.com" is correctly identified as the host.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
