### PR TITLE
Simplify connections

### DIFF
--- a/apps/api/app/cron/import/canny/migrate-posts.ts
+++ b/apps/api/app/cron/import/canny/migrate-posts.ts
@@ -35,7 +35,7 @@ const determineConnection = (
     create: {
       externalId: linkedIssue.id,
       href: linkedIssue.url,
-      atlassianInstallationId: installation.id,
+      type: 'JIRA',
       organizationId: installation.organizationId,
     },
   };

--- a/apps/api/app/cron/import/productboard/migrate-jira-connections.ts
+++ b/apps/api/app/cron/import/productboard/migrate-jira-connections.ts
@@ -110,8 +110,7 @@ export const migrateJiraConnections = async ({
       externalId: link.connection.issueId,
       featureId: feature.id,
       href: new URL(`/browse/${link.connection.issueKey}`, baseUrl).toString(),
-      atlassianInstallationId:
-        databaseOrganization.atlassianInstallations.at(0)?.id,
+      type: 'JIRA',
     });
   }
 

--- a/apps/api/app/webhooks/github/route.ts
+++ b/apps/api/app/webhooks/github/route.ts
@@ -41,16 +41,12 @@ const handleIssuesEvent = async (
   const featureConnection = await database.featureConnection.findFirst({
     where: {
       externalId: `${event.issue.id}`,
-      githubInstallationId: {
-        not: null,
-      },
-      // organizationId: installation.organizationId,
+      type: 'GITHUB',
     },
     select: {
       id: true,
       featureId: true,
       organizationId: true,
-      githubInstallationId: true,
     },
   });
 
@@ -67,7 +63,7 @@ const handleIssuesEvent = async (
       where: {
         organizationId: featureConnection.organizationId,
         eventType: event.action,
-        githubInstallationId: featureConnection.githubInstallationId,
+        type: 'GITHUB',
       },
       select: { featureStatusId: true },
     });

--- a/apps/api/app/webhooks/linear/route.ts
+++ b/apps/api/app/webhooks/linear/route.ts
@@ -38,28 +38,38 @@ const handleIssueUpdate = async (event: DataChangeEvent) => {
   const featureConnection = await database.featureConnection.findFirst({
     where: {
       externalId: event.data.id,
-      linearInstallationId: {
-        not: null,
-      },
+      type: 'LINEAR',
     },
     select: {
       id: true,
       featureId: true,
       organizationId: true,
-      linearInstallation: {
+      organization: {
         select: {
-          apiKey: true,
+          id: true,
+          linearInstallations: {
+            select: {
+              apiKey: true,
+            },
+          },
         },
       },
     },
   });
 
-  if (!featureConnection?.linearInstallation) {
+  if (!featureConnection) {
+    return new Response('OK');
+  }
+
+  const linearInstallation =
+    featureConnection.organization.linearInstallations.at(0);
+
+  if (!linearInstallation) {
     return new Response('OK');
   }
 
   const linear = new LinearClient({
-    apiKey: featureConnection.linearInstallation.apiKey,
+    apiKey: linearInstallation.apiKey,
   });
   const linearIssue = await linear.issue(event.data.issueId);
 
@@ -75,15 +85,12 @@ const handleIssueRemove = async (event: DataChangeEvent) => {
   const featureConnection = await database.featureConnection.findFirst({
     where: {
       externalId: event.data.id,
-      linearInstallationId: {
-        not: null,
-      },
+      type: 'LINEAR',
     },
     select: {
       id: true,
       featureId: true,
       organizationId: true,
-      githubInstallationId: true,
     },
   });
 

--- a/apps/app/actions/feature/list.ts
+++ b/apps/app/actions/feature/list.ts
@@ -23,13 +23,7 @@ export type GetFeaturesResponse = (Pick<
     AiFeatureRice,
     'confidence' | 'effort' | 'impact' | 'reach'
   > | null;
-  connection: Pick<
-    FeatureConnection,
-    | 'atlassianInstallationId'
-    | 'githubInstallationId'
-    | 'href'
-    | 'linearInstallationId'
-  > | null;
+  connection: Pick<FeatureConnection, 'type' | 'href'> | null;
   status: Pick<FeatureStatus, 'color' | 'complete' | 'id' | 'name' | 'order'>;
   product: Pick<Product, 'name'> | null;
   group: Pick<Group, 'name' | 'parentGroupId'> | null;
@@ -92,9 +86,7 @@ export const getFeatures = async (
           connection: {
             select: {
               href: true,
-              githubInstallationId: true,
-              atlassianInstallationId: true,
-              linearInstallationId: true,
+              type: true,
             },
           },
           status: {

--- a/apps/app/actions/installation-field-mapping/jira/update.ts
+++ b/apps/app/actions/installation-field-mapping/jira/update.ts
@@ -41,7 +41,8 @@ export const updateJiraFieldMappings = async (
     // 1. Delete existing mappings for the feature status
     await database.installationFieldMapping.deleteMany({
       where: {
-        atlassianInstallationId: installationId,
+        organizationId,
+        type: 'JIRA',
         internalId: internal.id,
       },
     });
@@ -57,7 +58,7 @@ export const updateJiraFieldMappings = async (
     const data: Prisma.InstallationFieldMappingCreateManyInput[] =
       externals.map((external) => ({
         organizationId,
-        atlassianInstallationId: installationId,
+        type: 'JIRA',
         internalId: internal.id,
         internalType: internal.type,
         externalId: external.id,

--- a/apps/app/actions/installation-status-mapping/github/create.ts
+++ b/apps/app/actions/installation-status-mapping/github/create.ts
@@ -54,7 +54,7 @@ export const createGitHubStatusMappings = async (): Promise<{
         featureStatusId: defaultFeatureStatus.id,
         creatorId: user.id,
         eventType: action,
-        githubInstallationId: gitHubInstallation.id,
+        type: 'GITHUB',
       }));
 
     await database.installationStatusMapping.createMany({

--- a/apps/app/actions/installation-status-mapping/jira/update.ts
+++ b/apps/app/actions/installation-status-mapping/jira/update.ts
@@ -38,7 +38,8 @@ export const updateJiraStatusMappings = async (
     // 1. Delete existing mappings for the feature status
     await database.installationStatusMapping.deleteMany({
       where: {
-        atlassianInstallationId: installationId,
+        type: 'JIRA',
+        organizationId,
         featureStatusId: featureStatusId,
       },
     });
@@ -54,7 +55,7 @@ export const updateJiraStatusMappings = async (
     const data: Prisma.InstallationStatusMappingCreateManyInput[] =
       jiraStatuses.map((jiraStatus) => ({
         organizationId,
-        atlassianInstallationId: installationId,
+        type: 'JIRA',
         featureStatusId: featureStatusId,
         eventId: jiraStatus.value,
         eventType: jiraStatus.label,

--- a/apps/app/app/(organization)/features/[feature]/components/feature-sidebar.tsx
+++ b/apps/app/app/(organization)/features/[feature]/components/feature-sidebar.tsx
@@ -112,9 +112,7 @@ export const FeatureSidebar = async ({
             select: {
               id: true,
               href: true,
-              githubInstallationId: true,
-              atlassianInstallationId: true,
-              linearInstallationId: true,
+              type: true,
             },
           },
           feedback: {
@@ -209,11 +207,11 @@ export const FeatureSidebar = async ({
 
   let featureConnectionSource = '';
 
-  if (feature.connection?.githubInstallationId) {
+  if (feature.connection?.type === 'GITHUB') {
     featureConnectionSource = '/github.svg';
-  } else if (feature.connection?.atlassianInstallationId) {
+  } else if (feature.connection?.type === 'JIRA') {
     featureConnectionSource = '/jira.svg';
-  } else if (feature.connection?.linearInstallationId) {
+  } else if (feature.connection?.type === 'LINEAR') {
     featureConnectionSource = '/linear.svg';
   }
 
@@ -365,15 +363,7 @@ export const FeatureSidebar = async ({
                 <span>View connected feature</span>
               </a>
             </Button>
-            {!feature.connection.githubInstallationId &&
-            !feature.connection.atlassianInstallationId &&
-            !feature.connection.linearInstallationId ? (
-              <p className="mt-1 text-center text-muted-foreground text-sm">
-                Syncing disabled
-              </p>
-            ) : (
-              <DisconnectButton connectionId={feature.connection.id} />
-            )}
+            <DisconnectButton connectionId={feature.connection.id} />
           </>
         ) : (
           <div className="flex flex-col">

--- a/apps/app/app/(organization)/features/components/features-list.tsx
+++ b/apps/app/app/(organization)/features/components/features-list.tsx
@@ -316,11 +316,11 @@ const createColumns = (
     cell: ({ row }) => {
       let featureConnectionSource = '';
 
-      if (row.original.connection?.githubInstallationId) {
+      if (row.original.connection?.type === 'GITHUB') {
         featureConnectionSource = '/github.svg';
-      } else if (row.original.connection?.atlassianInstallationId) {
+      } else if (row.original.connection?.type === 'JIRA') {
         featureConnectionSource = '/jira.svg';
-      } else if (row.original.connection?.linearInstallationId) {
+      } else if (row.original.connection?.type === 'LINEAR') {
         featureConnectionSource = '/linear.svg';
       }
 

--- a/apps/app/app/(organization)/initiatives/[initiative]/components/initiative-features.tsx
+++ b/apps/app/app/(organization)/initiatives/[initiative]/components/initiative-features.tsx
@@ -28,22 +28,17 @@ const InitiativeFeature = ({
 }: {
   feature: Pick<Feature, 'id' | 'title' | 'ownerId' | 'startAt' | 'endAt'> & {
     status: Pick<FeatureStatus, 'color'>;
-    connection: Pick<
-      FeatureConnection,
-      | 'atlassianInstallationId'
-      | 'linearInstallationId'
-      | 'githubInstallationId'
-    > | null;
+    connection: Pick<FeatureConnection, 'type'> | null;
   };
   readonly owner: User | undefined;
 }) => {
   let featureConnectionSource = null;
 
-  if (feature.connection?.githubInstallationId) {
+  if (feature.connection?.type === 'GITHUB') {
     featureConnectionSource = '/github.svg';
-  } else if (feature.connection?.atlassianInstallationId) {
+  } else if (feature.connection?.type === 'JIRA') {
     featureConnectionSource = '/jira.svg';
-  } else if (feature.connection?.linearInstallationId) {
+  } else if (feature.connection?.type === 'LINEAR') {
     featureConnectionSource = '/linear.svg';
   }
 
@@ -177,9 +172,7 @@ export const InitiativeFeatures = async ({
             },
             connection: {
               select: {
-                atlassianInstallationId: true,
-                linearInstallationId: true,
-                githubInstallationId: true,
+                type: true,
               },
             },
           },

--- a/apps/app/app/(organization)/settings/integrations/github/page.tsx
+++ b/apps/app/app/(organization)/settings/integrations/github/page.tsx
@@ -20,29 +20,33 @@ export const metadata: Metadata = createMetadata({
 });
 
 const GitHubIntegrationSettings = async () => {
-  const [featureStatuses, gitHubInstallation] = await Promise.all([
-    database.featureStatus.findMany({
-      orderBy: { order: 'asc' },
-      select: {
-        id: true,
-        name: true,
-        color: true,
-      },
-    }),
-    database.gitHubInstallation.findFirst({
-      select: {
-        id: true,
-        statusMappings: {
-          orderBy: { eventType: 'asc' },
-          select: {
-            id: true,
-            eventType: true,
-            featureStatusId: true,
-          },
+  const [featureStatuses, gitHubInstallation, statusMappings] =
+    await Promise.all([
+      database.featureStatus.findMany({
+        orderBy: { order: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          color: true,
         },
-      },
-    }),
-  ]);
+      }),
+      database.gitHubInstallation.findFirst({
+        select: {
+          id: true,
+        },
+      }),
+      database.installationStatusMapping.findMany({
+        where: {
+          type: 'GITHUB',
+        },
+        orderBy: { eventType: 'asc' },
+        select: {
+          id: true,
+          eventType: true,
+          featureStatusId: true,
+        },
+      }),
+    ]);
 
   if (!gitHubInstallation) {
     notFound();
@@ -53,7 +57,7 @@ const GitHubIntegrationSettings = async () => {
       <h1 className="font-semibold text-2xl">GitHub Integration</h1>
 
       <StackCard title="Status Mappings" className="p-0">
-        {gitHubInstallation.statusMappings.length > 0 ? (
+        {statusMappings.length > 0 ? (
           <Table className="mb-0">
             <TableHeader>
               <TableRow>
@@ -62,7 +66,7 @@ const GitHubIntegrationSettings = async () => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {gitHubInstallation.statusMappings.map((mapping) => (
+              {statusMappings.map((mapping) => (
                 <TableRow key={mapping.id}>
                   <TableCell className="font-medium font-mono">
                     {mapping.eventType}

--- a/apps/app/app/(organization)/settings/integrations/jira/components/jira-field-mappings/index.tsx
+++ b/apps/app/app/(organization)/settings/integrations/jira/components/jira-field-mappings/index.tsx
@@ -35,21 +35,26 @@ const fixedFields = [
 ];
 
 export const JiraFieldMappings = async () => {
-  const installation = await database.atlassianInstallation.findFirst({
-    select: {
-      id: true,
-      accessToken: true,
-      email: true,
-      siteUrl: true,
-      fieldMappings: {
-        select: {
-          id: true,
-          internalId: true,
-          externalId: true,
-        },
+  const [installation, fieldMappings] = await Promise.all([
+    database.atlassianInstallation.findFirst({
+      select: {
+        id: true,
+        accessToken: true,
+        email: true,
+        siteUrl: true,
       },
-    },
-  });
+    }),
+    database.installationFieldMapping.findMany({
+      where: {
+        type: 'JIRA',
+      },
+      select: {
+        id: true,
+        internalId: true,
+        externalId: true,
+      },
+    }),
+  ]);
 
   if (!installation) {
     return <div />;
@@ -85,7 +90,7 @@ export const JiraFieldMappings = async () => {
         ))}
       </div>
       <JiraFieldMappingTable
-        fieldMappings={installation.fieldMappings}
+        fieldMappings={fieldMappings}
         jiraFields={
           jiraFields.data
             ?.filter((field) => field.schema?.type)

--- a/apps/app/app/(organization)/settings/integrations/jira/components/jira-status-mappings/index.tsx
+++ b/apps/app/app/(organization)/settings/integrations/jira/components/jira-status-mappings/index.tsx
@@ -6,7 +6,7 @@ import { LinkIcon } from 'lucide-react';
 import { JiraStatusMappingTable } from './jira-status-mapping-table';
 
 export const JiraStatusMappings = async () => {
-  const [featureStatuses, installation] = await Promise.all([
+  const [featureStatuses, installation, statusMappings] = await Promise.all([
     database.featureStatus.findMany({
       orderBy: { order: 'asc' },
       select: {
@@ -21,16 +21,19 @@ export const JiraStatusMappings = async () => {
         accessToken: true,
         siteUrl: true,
         email: true,
-        statusMappings: {
-          orderBy: { eventType: 'asc' },
-          select: {
-            id: true,
-            eventType: true,
-            eventId: true,
-            featureStatusId: true,
-          },
-        },
       },
+    }),
+    database.installationStatusMapping.findMany({
+      where: {
+        type: 'JIRA',
+      },
+      select: {
+        id: true,
+        eventType: true,
+        eventId: true,
+        featureStatusId: true,
+      },
+      orderBy: { eventType: 'asc' },
     }),
   ]);
 
@@ -45,7 +48,7 @@ export const JiraStatusMappings = async () => {
     <StackCard title="Status Mappings" icon={LinkIcon} className="px-0 py-1.5">
       <JiraStatusMappingTable
         featureStatuses={featureStatuses}
-        statusMappings={installation.statusMappings}
+        statusMappings={statusMappings}
         jiraStatuses={
           jiraStatuses.data?.map((jiraStatus) => ({
             label: jiraStatus.name ?? '',

--- a/apps/app/components/connect-form/github/connect-to-github.ts
+++ b/apps/app/components/connect-form/github/connect-to-github.ts
@@ -51,7 +51,7 @@ export const connectToGitHub = async ({
         externalId,
         href,
         organizationId,
-        githubInstallationId: githubInstallation.id,
+        type: 'GITHUB',
       },
       select: { id: true },
     });

--- a/apps/app/components/connect-form/jira/connect-to-jira.ts
+++ b/apps/app/components/connect-form/jira/connect-to-jira.ts
@@ -37,7 +37,7 @@ export const connectToJira = async ({
         externalId,
         href,
         organizationId: atlassianInstallation.organizationId,
-        atlassianInstallationId: atlassianInstallation.id,
+        type: 'JIRA',
       },
       select: { id: true },
     });

--- a/apps/app/components/connect-form/linear/connect-to-linear.ts
+++ b/apps/app/components/connect-form/linear/connect-to-linear.ts
@@ -36,7 +36,7 @@ export const connectToLinear = async ({
         externalId,
         href,
         organizationId: linearInstallation.organizationId,
-        linearInstallationId: linearInstallation.id,
+        type: 'LINEAR',
       },
       select: { id: true },
     });

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -472,10 +472,6 @@ model FeatureConnection {
   organization         Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   feature              Feature                     @relation(fields: [featureId], references: [id], onDelete: Cascade)
   type                 feature_connection_platform
-  GitHubInstallation   GitHubInstallation?         @relation(fields: [gitHubInstallationId], references: [id])
-  gitHubInstallationId String?                     @db.VarChar(191)
-  LinearInstallation   LinearInstallation?         @relation(fields: [linearInstallationId], references: [id])
-  linearInstallationId String?                     @db.VarChar(191)
 
   @@index([externalId], map: "idx_33050_feature_connection_externalId_idx")
   @@index([organizationId], map: "idx_33050_feature_connection_organizationId_idx")

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -683,8 +683,6 @@ model GitHubInstallation {
   organizationId     String                      @db.VarChar(191)
   installationId     String                      @unique(map: "idx_33126_github_installation_installationId_key") @db.VarChar(191)
   organization       Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  statusMappings     InstallationStatusMapping[]
-  featureConnections FeatureConnection[]
 
   @@index([organizationId], map: "idx_33126_github_installation_organizationId_idx")
   @@map("github_installation")
@@ -776,8 +774,6 @@ model InstallationFieldMapping {
   organization   Organization                            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   type                    feature_connection_platform
-  AtlassianInstallation   AtlassianInstallation?      @relation(fields: [atlassianInstallationId], references: [id])
-  atlassianInstallationId String?                     @db.VarChar(191)
 
   @@unique([organizationId, externalId], map: "idx_33189_installation_field_mapping_organizationId_externalId_")
   @@map("installation_field_mapping")

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -698,8 +698,6 @@ model LinearInstallation {
   creatorId          String                      @db.VarChar(191)
   apiKey             String                      @db.VarChar(191)
   organization       Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  statusMappings     InstallationStatusMapping[]
-  featureConnections FeatureConnection[]
 
   @@index([organizationId], map: "idx_33213_linear_installation_organizationId_idx")
   @@map("linear_installation")
@@ -741,8 +739,6 @@ model AtlassianInstallation {
   email          String
   siteUrl        String
   organization   Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  statusMappings InstallationStatusMapping[]
-  fieldMappings  InstallationFieldMapping[]
 
   @@index([organizationId], map: "idx_32961_atlassian_installation_organizationId_idx")
   @@map("atlassian_installation")

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -462,16 +462,16 @@ model FeatureStatus {
 }
 
 model FeatureConnection {
-  id                   String                      @id(map: "idx_33050_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt            DateTime                    @default(now()) @db.Timestamptz(6)
-  updatedAt            DateTime                    @updatedAt @db.Timestamptz(6)
-  organizationId       String                      @db.VarChar(191)
-  featureId            String                      @unique(map: "idx_33050_feature_connection_featureId_key") @db.VarChar(191)
-  externalId           String                      @db.VarChar(191)
-  href                 String                      @db.VarChar(191)
-  organization         Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  feature              Feature                     @relation(fields: [featureId], references: [id], onDelete: Cascade)
-  type                 feature_connection_platform
+  id             String                      @id(map: "idx_33050_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime                    @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime                    @updatedAt @db.Timestamptz(6)
+  organizationId String                      @db.VarChar(191)
+  featureId      String                      @unique(map: "idx_33050_feature_connection_featureId_key") @db.VarChar(191)
+  externalId     String                      @db.VarChar(191)
+  href           String                      @db.VarChar(191)
+  organization   Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  feature        Feature                     @relation(fields: [featureId], references: [id], onDelete: Cascade)
+  type           feature_connection_platform
 
   @@index([externalId], map: "idx_33050_feature_connection_externalId_idx")
   @@index([organizationId], map: "idx_33050_feature_connection_organizationId_idx")
@@ -672,26 +672,26 @@ model ApiKey {
 }
 
 model GitHubInstallation {
-  id                 String                      @id(map: "idx_33126_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt          DateTime                    @default(now()) @db.Timestamptz(6)
-  updatedAt          DateTime                    @updatedAt @db.Timestamptz(6)
-  creatorId          String                      @db.VarChar(191)
-  organizationId     String                      @db.VarChar(191)
-  installationId     String                      @unique(map: "idx_33126_github_installation_installationId_key") @db.VarChar(191)
-  organization       Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id(map: "idx_33126_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime     @updatedAt @db.Timestamptz(6)
+  creatorId      String       @db.VarChar(191)
+  organizationId String       @db.VarChar(191)
+  installationId String       @unique(map: "idx_33126_github_installation_installationId_key") @db.VarChar(191)
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId], map: "idx_33126_github_installation_organizationId_idx")
   @@map("github_installation")
 }
 
 model LinearInstallation {
-  id                 String                      @id(map: "idx_33213_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt          DateTime                    @default(now()) @db.Timestamptz(6)
-  updatedAt          DateTime                    @updatedAt @db.Timestamptz(6)
-  organizationId     String                      @db.VarChar(191)
-  creatorId          String                      @db.VarChar(191)
-  apiKey             String                      @db.VarChar(191)
-  organization       Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  id             String       @id(map: "idx_33213_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime     @updatedAt @db.Timestamptz(6)
+  organizationId String       @db.VarChar(191)
+  creatorId      String       @db.VarChar(191)
+  apiKey         String       @db.VarChar(191)
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId], map: "idx_33213_linear_installation_organizationId_idx")
   @@map("linear_installation")
@@ -724,15 +724,15 @@ model IntercomInstallation {
 }
 
 model AtlassianInstallation {
-  id             String                      @id(map: "idx_32961_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt      DateTime                    @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime                    @updatedAt @db.Timestamptz(6)
-  creatorId      String                      @db.VarChar(191)
-  organizationId String                      @db.VarChar(191)
+  id             String       @id(map: "idx_32961_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime     @updatedAt @db.Timestamptz(6)
+  creatorId      String       @db.VarChar(191)
+  organizationId String       @db.VarChar(191)
   accessToken    String
   email          String
   siteUrl        String
-  organization   Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@index([organizationId], map: "idx_32961_atlassian_installation_organizationId_idx")
   @@map("atlassian_installation")
@@ -750,7 +750,7 @@ model InstallationStatusMapping {
   organization    Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   featureStatus   FeatureStatus @relation(fields: [featureStatusId], references: [id], onDelete: Cascade)
 
-  type                    feature_connection_platform
+  type feature_connection_platform
 
   @@unique([organizationId, featureStatusId, eventType, eventId], map: "idx_33201_installation_status_mapping_organizationId_featureSta")
   @@index([featureStatusId], map: "idx_33201_installation_status_mapping_featureStatusId_idx")
@@ -769,7 +769,7 @@ model InstallationFieldMapping {
   internalType   installation_field_mapping_internalType
   organization   Organization                            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  type                    feature_connection_platform
+  type feature_connection_platform
 
   @@unique([organizationId, externalId], map: "idx_33189_installation_field_mapping_organizationId_externalId_")
   @@map("installation_field_mapping")

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -462,28 +462,30 @@ model FeatureStatus {
 }
 
 model FeatureConnection {
-  id                      String                 @id(map: "idx_33050_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt               DateTime               @default(now()) @db.Timestamptz(6)
-  updatedAt               DateTime               @updatedAt @db.Timestamptz(6)
-  organizationId          String                 @db.VarChar(191)
-  featureId               String                 @unique(map: "idx_33050_feature_connection_featureId_key") @db.VarChar(191)
-  externalId              String                 @db.VarChar(191)
-  href                    String                 @db.VarChar(191)
-  githubInstallationId    String?                @db.VarChar(191)
-  linearInstallationId    String?                @db.VarChar(191)
-  atlassianInstallationId String?                @db.VarChar(191)
-  organization            Organization           @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  feature                 Feature                @relation(fields: [featureId], references: [id], onDelete: Cascade)
-  githubInstallation      GitHubInstallation?    @relation(fields: [githubInstallationId], references: [id])
-  linearInstallation      LinearInstallation?    @relation(fields: [linearInstallationId], references: [id])
-  atlassianInstallation   AtlassianInstallation? @relation(fields: [atlassianInstallationId], references: [id])
+  id                   String                      @id(map: "idx_33050_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt            DateTime                    @default(now()) @db.Timestamptz(6)
+  updatedAt            DateTime                    @updatedAt @db.Timestamptz(6)
+  organizationId       String                      @db.VarChar(191)
+  featureId            String                      @unique(map: "idx_33050_feature_connection_featureId_key") @db.VarChar(191)
+  externalId           String                      @db.VarChar(191)
+  href                 String                      @db.VarChar(191)
+  organization         Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  feature              Feature                     @relation(fields: [featureId], references: [id], onDelete: Cascade)
+  type                 feature_connection_platform
+  GitHubInstallation   GitHubInstallation?         @relation(fields: [gitHubInstallationId], references: [id])
+  gitHubInstallationId String?                     @db.VarChar(191)
+  LinearInstallation   LinearInstallation?         @relation(fields: [linearInstallationId], references: [id])
+  linearInstallationId String?                     @db.VarChar(191)
 
-  @@index([atlassianInstallationId], map: "idx_33050_feature_connection_atlassianInstallationId_idx")
   @@index([externalId], map: "idx_33050_feature_connection_externalId_idx")
-  @@index([githubInstallationId], map: "idx_33050_feature_connection_githubInstallationId_idx")
-  @@index([linearInstallationId], map: "idx_33050_feature_connection_linearInstallationId_idx")
   @@index([organizationId], map: "idx_33050_feature_connection_organizationId_idx")
   @@map("feature_connection")
+}
+
+enum feature_connection_platform {
+  JIRA
+  LINEAR
+  GITHUB
 }
 
 model FeatureRice {
@@ -730,65 +732,58 @@ model IntercomInstallation {
 }
 
 model AtlassianInstallation {
-  id                 String                      @id(map: "idx_32961_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt          DateTime                    @default(now()) @db.Timestamptz(6)
-  updatedAt          DateTime                    @updatedAt @db.Timestamptz(6)
-  creatorId          String                      @db.VarChar(191)
-  organizationId     String                      @db.VarChar(191)
-  accessToken        String
-  email              String
-  siteUrl            String
-  organization       Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  statusMappings     InstallationStatusMapping[]
-  featureConnections FeatureConnection[]
-  fieldMappings      InstallationFieldMapping[]
+  id             String                      @id(map: "idx_32961_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime                    @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime                    @updatedAt @db.Timestamptz(6)
+  creatorId      String                      @db.VarChar(191)
+  organizationId String                      @db.VarChar(191)
+  accessToken    String
+  email          String
+  siteUrl        String
+  organization   Organization                @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  statusMappings InstallationStatusMapping[]
+  fieldMappings  InstallationFieldMapping[]
 
   @@index([organizationId], map: "idx_32961_atlassian_installation_organizationId_idx")
   @@map("atlassian_installation")
 }
 
 model InstallationStatusMapping {
-  id                      String                 @id(map: "idx_33201_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt               DateTime               @default(now()) @db.Timestamptz(6)
-  updatedAt               DateTime               @updatedAt @db.Timestamptz(6)
-  creatorId               String                 @db.VarChar(191)
-  organizationId          String                 @db.VarChar(191)
-  featureStatusId         String                 @db.VarChar(191)
-  eventType               String                 @db.VarChar(191)
-  githubInstallationId    String?                @db.VarChar(191)
-  linearInstallationId    String?                @db.VarChar(191)
-  atlassianInstallationId String?                @db.VarChar(191)
-  eventId                 String?                @db.VarChar(191)
-  organization            Organization           @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  featureStatus           FeatureStatus          @relation(fields: [featureStatusId], references: [id], onDelete: Cascade)
-  githubInstallation      GitHubInstallation?    @relation(fields: [githubInstallationId], references: [id], onDelete: Cascade)
-  linearInstallation      LinearInstallation?    @relation(fields: [linearInstallationId], references: [id], onDelete: Cascade)
-  atlassianInstallation   AtlassianInstallation? @relation(fields: [atlassianInstallationId], references: [id], onDelete: Cascade)
+  id              String        @id(map: "idx_33201_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt       DateTime      @default(now()) @db.Timestamptz(6)
+  updatedAt       DateTime      @updatedAt @db.Timestamptz(6)
+  creatorId       String        @db.VarChar(191)
+  organizationId  String        @db.VarChar(191)
+  featureStatusId String        @db.VarChar(191)
+  eventType       String        @db.VarChar(191)
+  eventId         String?       @db.VarChar(191)
+  organization    Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  featureStatus   FeatureStatus @relation(fields: [featureStatusId], references: [id], onDelete: Cascade)
+
+  type                    feature_connection_platform
 
   @@unique([organizationId, featureStatusId, eventType, eventId], map: "idx_33201_installation_status_mapping_organizationId_featureSta")
-  @@index([atlassianInstallationId], map: "idx_33201_installation_status_mapping_atlassianInstallationId_i")
   @@index([featureStatusId], map: "idx_33201_installation_status_mapping_featureStatusId_idx")
-  @@index([githubInstallationId], map: "idx_33201_installation_status_mapping_githubInstallationId_idx")
-  @@index([linearInstallationId], map: "idx_33201_installation_status_mapping_linearInstallationId_idx")
   @@map("installation_status_mapping")
 }
 
 model InstallationFieldMapping {
-  id                      String                                  @id(map: "idx_33189_PRIMARY") @default(cuid()) @db.VarChar(191)
-  createdAt               DateTime                                @default(now()) @db.Timestamptz(6)
-  updatedAt               DateTime                                @updatedAt @db.Timestamptz(6)
-  creatorId               String                                  @db.VarChar(191)
-  organizationId          String                                  @db.VarChar(191)
-  externalId              String                                  @db.VarChar(191)
-  internalId              installation_field_mapping_internalId
-  atlassianInstallationId String?                                 @db.VarChar(191)
-  externalType            String                                  @db.VarChar(191)
-  internalType            installation_field_mapping_internalType
-  organization            Organization                            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  atlassianInstallation   AtlassianInstallation?                  @relation(fields: [atlassianInstallationId], references: [id], onDelete: Cascade)
+  id             String                                  @id(map: "idx_33189_PRIMARY") @default(cuid()) @db.VarChar(191)
+  createdAt      DateTime                                @default(now()) @db.Timestamptz(6)
+  updatedAt      DateTime                                @updatedAt @db.Timestamptz(6)
+  creatorId      String                                  @db.VarChar(191)
+  organizationId String                                  @db.VarChar(191)
+  externalId     String                                  @db.VarChar(191)
+  internalId     installation_field_mapping_internalId
+  externalType   String                                  @db.VarChar(191)
+  internalType   installation_field_mapping_internalType
+  organization   Organization                            @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  type                    feature_connection_platform
+  AtlassianInstallation   AtlassianInstallation?      @relation(fields: [atlassianInstallationId], references: [id])
+  atlassianInstallationId String?                     @db.VarChar(191)
 
   @@unique([organizationId, externalId], map: "idx_33189_installation_field_mapping_organizationId_externalId_")
-  @@index([atlassianInstallationId], map: "idx_33189_installation_field_mapping_atlassianInstallationId_id")
   @@map("installation_field_mapping")
 }
 


### PR DESCRIPTION
Detach installation ids from status / field mappings and feature connections to make them more resilient against integration changes.